### PR TITLE
[Back] /grass/other api 생성

### DIFF
--- a/backend/routes/routes.js
+++ b/backend/routes/routes.js
@@ -36,6 +36,7 @@ router.put('/grass', gitDataController.putData);
 // <-- grassController 
 router.get('/grass/personal', grassController.getPersonalGrass);
 router.get('/grass/challenge', grassController.getChallengeGrass);
+router.get('/grass/other', grassController.getOtherGrass);
 // grassController -->
 
 router.post('/challenge', challengeController.createChallenge);


### PR DESCRIPTION
nowchallenge 페이지에서 보일 other grass 용 api를 만들었습니다.

![image](https://user-images.githubusercontent.com/57705512/127429646-508d86bb-9454-4004-8ce6-99dfe2dcd883.png)

요청을 보내는 user의 grass는 제외하여 출력합니다.