### PR TITLE
비밀번호 변경 controller 수정

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -365,17 +365,34 @@ function VerifyToken(req, res, next) {
 
 async function ChangePw(req, res) {
 	try {
-		console.log(req.body);
+		const type = req.body.type;
+		// type : 0 
+			// 로그인전에 비밀번호 찾기 용
+			// 비밀번호 초기화 
+		// type : 1
+			// 로그인 후 마이페이지에서 비밀번호 변경 용
+			// 이전 비밀번호 확인 후, 맞으면 새 비밀번호로 변경 
 		const new_pw = req.body.new_pw;
 		const user_id = req.body.user_id;
-		const user = await User.findOne({ "user_id": user_id });
-		console.log(user);
-		if (user == undefined) {
-			res.status(201).json({ result: 'user not exists' });
-			return;
+		if (type == 0) { 
+			const user = await User.findOne({ "user_id": user_id });
+			console.log(user);
+			if (user == undefined) {
+				res.status(201).json({ result: 'user not exists' });
+				return;
+			}
+		}
+		else if (type == 1){
+			const user_pw = req.body.user_pw;
+			const user = await User.loginCheck(user_id, user_pw);
+			if (user === false) {
+				res.status(400).json({ error: 'wrong pw' });
+				return;
+			}
 		}
 		await User.changePw(user_id, new_pw);
 		res.status(201).json({ result: "success" });
+		
 	} catch (err) {
 		// console.log(err);
 		res.status(401).json({ error: err.message });


### PR DESCRIPTION
기존에 있던 비밀번호 변경 api를
마이페이지에서 비밀번호 변경할 때에도 쓰기 위해서 수정했습니다. 
body에 type필드를 추가해서 
type == 0 : 비밀번호 까먹었을 때
type == 1 : 마이페이지에서 비밀번호 변경할 때 (기존 비밀번호 확인)
로 나눠놨습니다. 

예시  
![image](https://user-images.githubusercontent.com/43634786/127867070-22a1664a-d937-4d0b-899a-427a16d1af82.png)
![image](https://user-images.githubusercontent.com/43634786/127867107-bfa75cac-ab89-4873-9b3f-2ffb8d9d7596.png)
