### PR TITLE
[프론트] approve api +invite api 연동

### DIFF
--- a/frontend/src/components/InviteModal.js
+++ b/frontend/src/components/InviteModal.js
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { Grid, Fade, Modal, TextField, Button, Backdrop } from '@material-ui/core';
+import { API_URL } from '../CommonVariable';
+
+function InviteModal({ open, closeHandler, CId }) {
+	const [email, setEmail] = useState("");
+	const emailHandler = (e) => {
+		e.preventDefault();
+		setEmail(e.target.value);
+	};
+	const inviteHandler = (e) => {
+		e.preventDefault();
+		axios.post(`${API_URL}/invite`, {
+			challenge_id: CId,
+			user_email: email
+		}).then((res) => {
+			console.log(res.data);
+			alert(`${email}로 초대 메일을 성공적으로 보냈습니다.`);
+			closeHandler();
+			setEmail("");
+		}).catch((e) => {
+			alert(`${e} 오류가 발생했습니다.`);
+		});
+	};
+	return (
+		<Modal
+			className="modal"
+			open={open}
+			onClose={closeHandler}
+			closeAfterTransition
+			BackdropComponent={Backdrop}
+			BackdropProps={{
+				timeout: 500,
+			}}
+		>
+			<Fade in={open}>
+				<Grid className="inviteModalPaper">
+					<Grid className="head">초대하기</Grid>
+					<Grid className="body">
+						<form onSubmit={inviteHandler}>
+							<Grid className="input-con">
+								<TextField
+									variant="outlined"
+									label="E-mail"
+									fullWidth
+									value={email}
+									onChange={emailHandler}
+								/>
+								<Button
+									style={{ marginLeft: '1rem', backgroundColor: '#CCFCCB', height: '100%' }}
+									type="submit"
+								>
+									전송
+								</Button>
+							</Grid>
+						</form>
+						{/* 다인 초대는 추후지원 */}
+						{/* <Grid className="icon-con">
+							<IconButton style={{ width: '2rem', height: '2rem' }}>
+								<AddIcon />
+							</IconButton>
+						</Grid> */}
+					</Grid>
+				</Grid>
+			</Fade>
+		</Modal>
+	);
+}
+
+export default InviteModal;

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -7,3 +7,4 @@ export { default as LogInForm } from './LogInForm';
 export { default as ManageComponent } from './ManageComponent';
 export { default as useSessionStorage } from './useSessionStorage';
 export { default as PwFindAuth } from './PwFindAuth';
+export { default as InviteModal } from './InviteModal';

--- a/frontend/src/pages/NowChallenge.js
+++ b/frontend/src/pages/NowChallenge.js
@@ -8,11 +8,13 @@ import { useChallengeState } from '../MVVM/Model/ChallengeModel';
 import { useGetChallenge } from '../MVVM/ViewModel/ChallengeViewModel';
 import { API_URL } from '../CommonVariable';
 import { useUserState } from '../MVVM/Model/UserModel';
+import { InviteModal } from '../components';
 
 function NowChallenge({ match }) {
 	const history = useHistory();
 	const CId = match.params.challengeId;
 	const challengeData = useChallengeState();
+	console.log(challengeData);
 	const userData = useUserState();
 	const [title, setTitle] = useState("");
 	const [inviteOpen, setInviteOpen] = useState(false);
@@ -34,6 +36,10 @@ function NowChallenge({ match }) {
 	const [admit, setAdmit] = useState(null);
 	const today = new Date();
 	useEffect(() => {
+		// todo : 가입한 사람이 아니면 모달 띄우기
+		axios.get(`${API_URL}/challenge/${CId}`).then((res) => {
+			console.log(res.data);
+		});
 		// todo : grass mvvm 만들기. approve mvvm 이용하기.
 		const result = challengeData.filter((item) => item.challenge_id === CId);
 		result.map((c, i) => {
@@ -68,7 +74,6 @@ function NowChallenge({ match }) {
 		} }).then((res) => {
 			const temp = [];
 			res.data.OtherList.map((d) => temp.push(d.flat()));
-			console.log(temp);
 			setOtherGrass(temp);
 		});
 		// king
@@ -82,7 +87,6 @@ function NowChallenge({ match }) {
 		// approve
 		axios.get(`${API_URL}/approve/list/${CId}`).then((res) => {
 			setAdmit(res.data);
-			console.log(res.data);
 		});
 	}, [challengeData]);
 	// <-- grass carousel setting
@@ -97,6 +101,25 @@ function NowChallenge({ match }) {
 	// grass carousel setting -->
 	const grassHandler = () => {
 		history.push(`/challenge/info/${CId}/fix`);
+	};
+	const [email, setEmail] = useState("");
+	const emailHandler = (e) => {
+		e.preventDefault();
+		setEmail(e.target.value);
+	};
+	const inviteHandler = (e) => {
+		e.preventDefault();
+		axios.post(`${API_URL}/invite`, {
+			challenge_id: CId,
+			user_email: email
+		}).then((res) => {
+			console.log(res.data);
+			alert(`${email}로 초대 메일을 성공적으로 보냈습니다.`);
+			setInviteOpen(false);
+			setEmail("");
+		}).catch((e) => {
+			alert(`${e} 오류가 발생했습니다.`);
+		});
 	};
 	return (
 		<>
@@ -165,34 +188,7 @@ function NowChallenge({ match }) {
 					</Grid>
 				</Grid>
 			</Grid>
-			<Modal
-				className="modal"
-				open={inviteOpen}
-				onClose={() => setInviteOpen(false)}
-				closeAfterTransition
-				BackdropComponent={Backdrop}
-				BackdropProps={{
-					timeout: 500,
-				}}
-			>
-				<Fade in={inviteOpen}>
-					<Grid className="inviteModalPaper">
-						<Grid className="head">초대하기</Grid>
-						<Grid className="body">
-							<Grid className="input-con">
-								<TextField variant="outlined" label="E-mail" fullWidth />
-								<Button style={{ marginLeft: '1rem', backgroundColor: '#CCFCCB', height: '100%' }}>전송</Button>
-							</Grid>
-							{/* 다인 초대는 추후지원 */}
-							{/* <Grid className="icon-con">
-								<IconButton style={{ width: '2rem', height: '2rem' }}>
-									<AddIcon />
-								</IconButton>
-							</Grid> */}
-						</Grid>
-					</Grid>
-				</Fade>
-			</Modal>
+			<InviteModal open={inviteOpen} closeHandler={() => setInviteOpen(false)} CId={CId} />
 			<Modal
 				className="modal"
 				open={admitOpen}


### PR DESCRIPTION
## 구현사항
* nowChallenge approve api 연동
* nowchallenge의 invite api 연동
  * 추후에 혹시 쓸 수 있도록 component화
* 가입한 사람이 아닐 시 비밀번호 모달 띄우는 거 논의사항에 올려둠. 구현 전.

## Todo
* 초대 -> 가입 로직 짠 후에 가입 부분 수정
* 승인 모달 디자인 수정

## 실행사진
![image](https://user-images.githubusercontent.com/57705512/128197170-eb50b353-aab6-414c-9edc-3163dbdeb378.png)
![image](https://user-images.githubusercontent.com/57705512/128197226-281c9707-0079-4ef0-8750-bfed874fdeff.png)
