### PR TITLE
[Back] Challenge out API 완성 

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -176,16 +176,24 @@ function GetChallengeList(req, res) {		// userId를 기반으로 user의 ch_list
 }
 
 function OutChallenge(req, res) {
+	//user의 ch_list에서 해당 ch 삭제
+	//ch의 challenge_user에서 해당 user 삭제 
+	// 둘다 성공시에만 success return 
+
+	// TODO : 
+		// 1 - 실패시에도 res 보내줘야함
+		// 2 - 유저스키마 건드린 후, 챌린지 스키마 완료되기 전에 에러 발생한다면 rollback 시켜줘야함 
 	const { userId, challengeId } = req.body;
 
 	const id = ObjectID(challengeId);
 
-	var chArray
+	var chArray;
 
 	User.findOneByUsername(userId)
 		.then((user) => {
-			chArray = user.ch_list
-
+			chArray = user.ch_list; // user의 ch_list
+			
+			// user의 ch_list에서 해당 challenge를 찾아보고 있으면 1, 없으면 0 return
 			for (let i = 0; i < chArray.length; i++) {
 				_id = ObjectID(chArray[i]);
 				temp1 = JSON.stringify(id);
@@ -193,7 +201,7 @@ function OutChallenge(req, res) {
 
 				if (temp1 == temp2) {
 					console.log(chArray[i]);
-					chArray.splice(i, i);
+					chArray.splice(i, i); // i번째 요소 제거 
 					return 1;
 				}
 			}
@@ -202,7 +210,7 @@ function OutChallenge(req, res) {
 		.then((state) => {
 			if (state === 0)
 				throw new Error('user DB에 해당 challenge 없음.')
-			outch(chArray)
+			outch(chArray) // user의 ch_list에서 해당 challenge 제거 (탈퇴진행)
 		})
 		.catch((err) => {
 			console.error(err);
@@ -290,7 +298,7 @@ function OutChallenge(req, res) {
 			console.log(doc._id)
 			res.send("success")
 		}
-	})
+	});
 }
 
 async function LogIn(req, res, next) {

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -195,27 +195,20 @@ async function OutChallenge(req, res) {
 		if (ch.challenge_users.length === 0 || ch.challenge_users.find(element => element === user_id) === undefined) throw new Error('challege DB에 해당 user 없음.');
 
 		const session = await mongoose.startSession(); // 무결성 보장을 위한 transation 처리
-		try {
-			await session.withTransaction(async () =>  {
-				//ch의 challenge_user에서 해당 user 삭제 
-				await Challenge.findOneAndUpdate(
-					{_id : ch_id},
-					{$pull: {'challenge_users': user_id, 'commitCount': {'user_id' :user_id}},
-					$inc: {'challenge_user_num' : -1}}
-				);
-				//user의 ch_list에서 해당 ch 삭제
-				await User.findOneAndUpdate(
-					{'user_id':user_id},
-					{$pull: {'ch_list': challenge_id}}
-				);
-			});
-			session.endSession();	
-		}
-		catch(err){
-			await session.abortTransaction();
-			session.endSession();
-			throw new Error("transaction 처리 에러");
-		}
+		await session.withTransaction(async () =>  {
+			//ch의 challenge_user에서 해당 user 삭제 
+			await Challenge.findOneAndUpdate(
+				{_id : ch_id},
+				{$pull: {'challenge_users': user_id, 'commitCount': {'user_id' :user_id}},
+				$inc: {'challenge_user_num' : -1}}
+			);
+			//user의 ch_list에서 해당 ch 삭제
+			await User.findOneAndUpdate(
+				{'user_id':user_id},
+				{$pull: {'ch_list': challenge_id}}
+			);
+		});
+		await session.endSession();	
 		res.send({"success":true});
 	} catch (err) {
 		console.log(err);

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -175,11 +175,6 @@ function GetChallengeList(req, res) {		// userId를 기반으로 user의 ch_list
 
 }
 
-/**
- * 이것은 무슨 함수이다.
- * @param {json} req 
- * @param {json} res 
- */
 async function OutChallenge(req, res) {
 	//user의 ch_list에서 해당 ch 삭제
 	//ch의 challenge_user에서 해당 user 삭제 
@@ -204,17 +199,13 @@ async function OutChallenge(req, res) {
 			//ch의 challenge_user에서 해당 user 삭제 
 			await Challenge.findOneAndUpdate(
 				{_id : ch_id},
-				{
-					$pull: {'challenge_users': user_id, 'commitCount': {'user_id' :user_id}},
-					$inc: {'challenge_user_num' : -1},
-					//$pull : {'commitCount': {'user_id' :user_id}}
-				}
+				{$pull: {'challenge_users': user_id, 'commitCount': {'user_id' :user_id}},
+				$inc: {'challenge_user_num' : -1}}
 			);
 			//user의 ch_list에서 해당 ch 삭제
 			await User.findOneAndUpdate(
 				{'user_id':user_id},
-				{
-					$pull: {'ch_list': challenge_id}}
+				{$pull: {'ch_list': challenge_id}}
 			);
 		});
 		await session.endSession();	

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -183,13 +183,13 @@ function OutChallenge(req, res) {
 	// TODO : 
 		// 1 - 실패시에도 res 보내줘야함
 		// 2 - 유저스키마 건드린 후, 챌린지 스키마 완료되기 전에 에러 발생한다면 rollback 시켜줘야함 
-	const { userId, challengeId } = req.body;
+	const { user_id, challenge_id } = req.body;
 
-	const id = ObjectID(challengeId);
+	const id = ObjectID(challenge_id);
 
 	var chArray;
 
-	User.findOneByUsername(userId)
+	User.findOneByUsername(user_id)
 		.then((user) => {
 			chArray = user.ch_list; // user의 ch_list
 			
@@ -216,7 +216,7 @@ function OutChallenge(req, res) {
 			console.error(err);
 		})
 
-	const outch = (chArray) => User.findOneAndUpdate({ user_id: userId }, {
+	const outch = (chArray) => User.findOneAndUpdate({ user_id: user_id }, {
 		$set: {
 			ch_list: chArray
 		}
@@ -239,7 +239,7 @@ function OutChallenge(req, res) {
 
 			for (let i = 0; i < userAry.length; i++) {
 				_id = userAry[i]
-				temp1 = JSON.stringify(userId);
+				temp1 = JSON.stringify(user_id);
 				temp2 = JSON.stringify(_id);
 
 				if (temp1 == temp2) {
@@ -255,7 +255,7 @@ function OutChallenge(req, res) {
 			for (let i = 0; i < userCommitAry.length; i++) {
 				_id = userCommitAry[i]
 
-				temp1 = JSON.stringify(userId);
+				temp1 = JSON.stringify(user_id);
 				temp2 = JSON.stringify(_id.user_id);
 
 				if (temp1 == temp2) {

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -180,7 +180,8 @@ async function OutChallenge(req, res) {
 	//ch의 challenge_user에서 해당 user 삭제 
 	// 둘다 성공시에만 success return (transaction 처리)
 	try {
-		const { user_id, challenge_id } = req.body;
+		const { user_id } = req.body;
+		const { challenge_id } = req.params;
 		const ch_id = ObjectID(challenge_id);
 
 		const ch = await Challenge.findById(ch_id);
@@ -216,7 +217,7 @@ async function OutChallenge(req, res) {
 			session.endSession();
 			throw new Error("transaction 처리 에러");
 		}
-		res.send({"success":true});
+		res.send({'success':true});
 	} catch (err) {
 		console.log(err);
 		res.status(400).json({ error: err.message });

--- a/backend/routes/routes.js
+++ b/backend/routes/routes.js
@@ -13,7 +13,7 @@ const authMailController = require('../controllers/authMailController');
 router.post('/signup', userController.createUser);
 router.delete('/signout/:id', userController.deleteUser);
 router.get('/challenge/list/:userId', userController.getChallengeList);
-router.patch('/challengeOut/user', userController.outChallenge);
+router.patch('/user/:challenge_id/out', userController.outChallenge);
 router.post('/login', userController.logIn);
 router.post('/logout', userController.logOut);
 router.post('/auth/jwtvalidcheck', userController.verifyToken);

--- a/frontend/src/CommonVariable.js
+++ b/frontend/src/CommonVariable.js
@@ -2,7 +2,7 @@
 // export const API_URL = "https://challengeback.herokuapp.com";
 
 // 로컬 프론트 & 백 테스트용
-// export const API_URL = "http://localhost:5000";
+ export const API_URL = "http://localhost:5000";
 
 // 배포용
-export const API_URL = "https://alsolvechallenge.herokuapp.com";
+// export const API_URL = "https://alsolvechallenge.herokuapp.com";

--- a/frontend/src/CommonVariable.js
+++ b/frontend/src/CommonVariable.js
@@ -2,7 +2,7 @@
 // export const API_URL = "https://challengeback.herokuapp.com";
 
 // 로컬 프론트 & 백 테스트용
- export const API_URL = "http://localhost:5000";
+// export const API_URL = "http://localhost:5000";
 
 // 배포용
-// export const API_URL = "https://alsolvechallenge.herokuapp.com";
+export const API_URL = "https://alsolvechallenge.herokuapp.com";


### PR DESCRIPTION
- 챌린지 탈퇴 api 작성 

- user DB 수정, challenge DB 수정을 transaction으로 묶어서 데이터 무결성이 보장될 수 있도록 처리해줌 
- postman 요청 결과는 이러함. error시에는 400과 함께 error메세지가 날아옴
![image](https://user-images.githubusercontent.com/43634786/130314811-a09cce89-8cc7-427f-a8f8-870474ecf842.png)

- user DB에서는, ch_list 배열에서 해당 challengeID 삭제 
- challenge DB에서는, challenge_users 배열에서 해당 user_id 삭제, challenge_users_num --. commitCount 배열에서 해당 user_id 삭제

- 예외 처리?
1. 챌린지 장이면 error 
2. user DB에 해당 챌린지가 들어있지 않거나, challenge DB에 해당 user가 들어있지 않으면 error