### PR TITLE
[develop] 로그인 관련 수정 (JWT, React상태관리 등..)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -42,7 +42,7 @@ app.use(expressSession({
 }))
 app.use(bodyParser.json());
 app.use(cookieParser());
-app.use(jwtMiddleware);
+app.use(jwtMiddleware); // jwt 해석해서 user정보 req에 넣어주는 미들웨어
 app.use('/',router);
 
 if(process.env.NODE_ENV=='production') {

--- a/backend/app.js
+++ b/backend/app.js
@@ -4,21 +4,15 @@ const cookieParser = require('cookie-parser');
 const cors = require('cors');
 const expressSession = require('express-session');
 const path = require('path');
-
 const port = process.env.PORT || 5000;
-
 const bodyParser = require('body-parser')
-
 const router = require('./routes/routes');
-
-
 const config = require('./config/key');
-
+const { jwtMiddleware } = require('./lib/token');
 const mongoose = require('mongoose');
 
 require("dotenv").config();
 const cookieSecret = process.env.COOKIE_SECRET;
-
 
 mongoose.connect(config.mongoURI,{
     useNewUrlParser: true, useUnifiedTopology: true, useCreateIndex:true, useFindAndModify:false
@@ -48,6 +42,7 @@ app.use(expressSession({
 }))
 app.use(bodyParser.json());
 app.use(cookieParser());
+app.use(jwtMiddleware);
 app.use('/',router);
 
 if(process.env.NODE_ENV=='production') {

--- a/backend/controllers/controller.js
+++ b/backend/controllers/controller.js
@@ -113,10 +113,10 @@ Challenge.findOneById(id)
 
 
 const join = (challenge) => {
-	// challenge에 userId 추가.
+	// challenge에 user_id 추가.
 	userArray = challenge.challenge_users;
 	userCount = challenge.challenge_user_num + 1;
-	userArray.push(userId);
+	userArray.push(user_id);
 	db.collection("challenges").updateOne({ _id: id }, {
 		$set: {
 			challenge_users: userArray,

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -71,7 +71,7 @@ function DeleteUser(req, res) {
 	var length = len(chlist);
 
 	for (let i = 0; i < length; i++) {
-		OutChallenge({ userId: _id, challengeId: chlist[i] },)
+		OutChallenge({ user_id: _id, challengeId: chlist[i] },)
 
 	}
 
@@ -92,8 +92,8 @@ function DeleteUser(req, res) {
 
 }
 
-function GetChallengeList(req, res) {		// userId를 기반으로 user의 ch_list반환.
-	const userId = req.params.userId;
+function GetChallengeList(req, res) {		// user_id를 기반으로 user의 ch_list반환.
+	const user_id = req.params.user_id;
 
 	var challengeList = [];
 
@@ -156,7 +156,7 @@ function GetChallengeList(req, res) {		// userId를 기반으로 user의 ch_list
 			return challengeList
 		}
 
-		User.findOneByUsername(userId)
+		User.findOneByUsername(user_id)
 			.then((user) => {
 				if (user) {
 					list = user.ch_list;
@@ -179,13 +179,13 @@ function GetChallengeList(req, res) {		// userId를 기반으로 user의 ch_list
 }
 
 function OutChallenge(req, res) {
-	const { userId, challengeId } = req.body;
+	const { user_id, challengeId } = req.body;
 
 	const id = ObjectID(challengeId);
 
 	var chArray
 
-	User.findOneByUsername(userId)
+	User.findOneByUsername(user_id)
 		.then((user) => {
 			chArray = user.ch_list
 
@@ -211,7 +211,7 @@ function OutChallenge(req, res) {
 			console.error(err);
 		})
 
-	const outch = (chArray) => User.findOneAndUpdate({ user_id: userId }, {
+	const outch = (chArray) => User.findOneAndUpdate({ user_id: user_id }, {
 		$set: {
 			ch_list: chArray
 		}
@@ -234,7 +234,7 @@ function OutChallenge(req, res) {
 
 			for (let i = 0; i < userAry.length; i++) {
 				_id = userAry[i]
-				temp1 = JSON.stringify(userId);
+				temp1 = JSON.stringify(user_id);
 				temp2 = JSON.stringify(_id);
 
 				if (temp1 == temp2) {
@@ -250,7 +250,7 @@ function OutChallenge(req, res) {
 			for (let i = 0; i < userCommitAry.length; i++) {
 				_id = userCommitAry[i]
 
-				temp1 = JSON.stringify(userId);
+				temp1 = JSON.stringify(user_id);
 				temp2 = JSON.stringify(_id.user_id);
 
 				if (temp1 == temp2) {
@@ -319,21 +319,14 @@ async function LogIn(req, res, next) {
 			  	git_id: user.git_id,
 			}
 			const token = createToken(payload);
-			console.log(token);
-			// const token = jwt.sign({
-			// 	user_id: user.user_id,
-			// 	git_id: user.git_id,
-			// }
-			// 	, SecretKey, {
-			// 	expiresIn: '1h'
-			// }
-			// );
+			//console.log(token);
 			res.cookie('user', token, { //httpOnly:true, 
 				sameSite: 'none', secure: true });
 			console.log('git data 교체 --------------------',id)
 			await CreateGitData(id);
 			res.status(201).json({
-				result: true
+				result: true,
+				user : payload
 			});
 		}	
 	} catch (err) {

--- a/backend/functions/crawling.js
+++ b/backend/functions/crawling.js
@@ -22,9 +22,9 @@ const getDate = () => {
 }
 
 /*
-	crawlingModule(gitId)
+	crawlingModule(git_id)
 	axios와 cheerio를 이용하여 깃허브 사이트 크롤링!
-	props로 받은 gitId를 이용함.
+	props로 받은 git_id를 이용함.
 	result = [
 	{ date: '2021-01-01', count: '0' },
     { date: '2021-01-02', count: '0' },
@@ -32,11 +32,11 @@ const getDate = () => {
 	...
 	]
 */
-const crawlingModule = async (gitId) => {
+const crawlingModule = async (git_id) => {
 	let result = [];
 	const to = getDate();
 	for(let i=0; i<to.length; i++){
-		await axios.get(`https://github.com/${gitId}?tab=overview&from=${to[i]}-01-01&to=${to[i]}-12-31`)
+		await axios.get(`https://github.com/${git_id}?tab=overview&from=${to[i]}-01-01&to=${to[i]}-12-31`)
 		.then(html => {
 			$ = cheerio.load(html.data);
 			const crawl = $('svg > g > g > rect');
@@ -143,20 +143,20 @@ const isLastDay = (date) => {
 }
 
 /* 유저의 깃 데이터 만들기. 이미 있으면 최신화, 없으면 새로 만들어줌! */
-async function CreateGitData(userId) {
-	const user = await User.findOneByUsername(userId);
+async function CreateGitData(user_id) {
+	const user = await User.findOneByUsername(user_id);
 	if (user) {
 		// 이미 생성된 grass가 있는지?
-		const grass = await gitData.findOneByUserId(userId)
+		const grass = await gitData.findOneByUserId(user_id)
 		if(grass) {
-			gitData.findOneAndDelete({ user_id: userId }, function (err,docs) {
+			gitData.findOneAndDelete({ user_id: user_id }, function (err,docs) {
 				if (err) { console.log(err) }
 				else { console.log("Deleted: ", docs); }
 			})
 		}
 		// 깃 크롤링
 		const commit_data = await crawlingModule(user.git_id);
-		await gitData.create(userId, user.git_id, commit_data);
+		await gitData.create(user_id, user.git_id, commit_data);
 	} else {
 		throw 'user not exists';
 	}

--- a/backend/lib/token.js
+++ b/backend/lib/token.js
@@ -25,12 +25,12 @@ async function jwtMiddleware(req, res, next) {
         if (decoded.exp - Date.now()/1000 < renewTiming) {
             const { user_id, git_id } = decoded;
             const freshToken = createToken({ user_id, git_id });
-            res.cookie('user', token, { httpOnly: true, sameSite: 'none', secure: true });
+            res.cookie('user', freshToken, { httpOnly: true, sameSite: 'none', secure: true });
         }
         req.user = decoded;
     } catch(e) {
         // token validation 실패  
-        console.log(e);
+        console.log("token validation fail");
         req.user = null;
     }
     return next();

--- a/backend/lib/token.js
+++ b/backend/lib/token.js
@@ -14,7 +14,7 @@ function decodeToken(token) {
 
 async function jwtMiddleware(req, res, next) {
     const token = req.cookies.user;
-
+    console.log(token);
     if (!token) return next(); // 토큰이 없으면 바로 다음 작업 진행
 
     try {
@@ -29,7 +29,8 @@ async function jwtMiddleware(req, res, next) {
         }
         req.user = decoded;
     } catch(e) {
-        // token validation 실패  
+        // token validation 실패 
+        console.log(e); 
         console.log("token validation fail");
         req.user = null;
     }

--- a/backend/lib/token.js
+++ b/backend/lib/token.js
@@ -1,0 +1,38 @@
+const jwt = require('jsonwebtoken');
+require("dotenv").config();
+const jwtSecret = process.env.SECRET_KEY;
+
+
+function createToken(payload) {
+    return jwt.sign(payload, jwtSecret, { expiresIn: '30m'});
+}
+exports.createToken = createToken;
+
+function decodeToken(token) {
+    return jwt.verify(token, jwtSecret);
+}
+
+async function jwtMiddleware(req, res, next) {
+    const token = req.cookies.user;
+
+    if (!token) return next(); // 토큰이 없으면 바로 다음 작업 진행
+
+    try {
+        const decoded = await decodeToken(token);
+        //console.log(decoded); // iat: 발급 시점, exp: 만료 시점 (초 단위)
+        const renewTiming = 5 * 60;
+        //refreshToken 안 쓰는 방식. accessToken만 이용
+        if (decoded.exp - Date.now()/1000 < renewTiming) {
+            const { user_id, git_id } = decoded;
+            const freshToken = createToken({ user_id, git_id });
+            res.cookie('user', token, { httpOnly: true, sameSite: 'none', secure: true });
+        }
+        req.user = decoded;
+    } catch(e) {
+        // token validation 실패  
+        console.log(e);
+        req.user = null;
+    }
+    return next();
+}
+exports.jwtMiddleware = jwtMiddleware;

--- a/backend/lib/token.js
+++ b/backend/lib/token.js
@@ -2,7 +2,6 @@ const jwt = require('jsonwebtoken');
 require("dotenv").config();
 const jwtSecret = process.env.SECRET_KEY;
 
-
 function createToken(payload) {
     return jwt.sign(payload, jwtSecret, { expiresIn: '30m'});
 }
@@ -15,25 +14,25 @@ function decodeToken(token) {
 async function jwtMiddleware(req, res, next) {
     const token = req.cookies.user;
     console.log(token);
-    if (!token) return next(); // 토큰이 없으면 바로 다음 작업 진행
+    if (!token) next(); // 토큰이 없으면 바로 종료
 
     try {
         const decoded = await decodeToken(token);
         //console.log(decoded); // iat: 발급 시점, exp: 만료 시점 (초 단위)
-        const renewTiming = 5 * 60;
+        const renewTiming = 5 * 60; // 토큰 만료 시간이 5분 남았으면 재발급
         //refreshToken 안 쓰는 방식. accessToken만 이용
         if (decoded.exp - Date.now()/1000 < renewTiming) {
             const { user_id, git_id } = decoded;
             const freshToken = createToken({ user_id, git_id });
             res.cookie('user', freshToken, { httpOnly: true, sameSite: 'none', secure: true });
         }
-        req.user = decoded;
+        req.user = decoded; // !!이후의 컨트롤러에서 req.user로 접근해서 user정보 확인하면됨
     } catch(e) {
         // token validation 실패 
         console.log(e); 
         console.log("token validation fail");
         req.user = null;
     }
-    return next();
+    next();
 }
 exports.jwtMiddleware = jwtMiddleware;

--- a/backend/models/challengeModel.js
+++ b/backend/models/challengeModel.js
@@ -63,21 +63,21 @@ var Challenge = new Schema({
 	versionKey: false
 });
 
-Challenge.statics.create = function (userId, name, challenge_start, challenge_end, private_key, vacation_count) {
+Challenge.statics.create = function (user_id, name, challenge_start, challenge_end, private_key, vacation_count) {
 	const challenge = new this({
 		name,
 		challenge_start,
 		challenge_end,
-		challenge_leader: userId,
+		challenge_leader: user_id,
 		private_key,
 		vacation_count
 	})
 
-	const commitCount = challenge.commitCount.create({ user_id: userId })
+	const commitCount = challenge.commitCount.create({ user_id: user_id })
 
 	challenge.commitCount = commitCount
 
-	challenge.challenge_users.push(userId)
+	challenge.challenge_users.push(user_id)
 	//commitCount 추가.
 
 	console.log(challenge);

--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -16,7 +16,6 @@ var User = new Schema({
 });
 
 User.pre("save", function(next) {
-	console.log("aaaaaaaaa");
 	var user = this;
 	if (user.isModified("user_pw")) {
 		bcrypt.genSalt(10, (err,salt) => {

--- a/backend/routes/routes.js
+++ b/backend/routes/routes.js
@@ -13,7 +13,7 @@ const alarmController = require('../controllers/alarmController');
 // <-- userCon
 router.post('/signup', userController.createUser);
 router.delete('/signout/:id', userController.deleteUser);
-router.get('/challenge/list/:userId', userController.getChallengeList);
+router.get('/challenge/list/:user_id', userController.getChallengeList);
 router.patch('/challengeOut/user', userController.outChallenge);
 router.post('/login', userController.logIn);
 router.post('/logout', userController.logOut);

--- a/backend/routes/routes.js
+++ b/backend/routes/routes.js
@@ -17,7 +17,7 @@ router.get('/challenge/list/:user_id', userController.getChallengeList);
 router.patch('/challengeOut/user', userController.outChallenge);
 router.post('/login', userController.logIn);
 router.post('/logout', userController.logOut);
-router.post('/check', userController.check);
+router.get('/check', userController.check);
 router.get('/user/uniqueid/:user_id', userController.checkIdDupl);
 router.patch('/user/changepw', userController.changePw);
 router.patch('/user/change', userController.change);

--- a/backend/routes/routes.js
+++ b/backend/routes/routes.js
@@ -17,7 +17,7 @@ router.get('/challenge/list/:userId', userController.getChallengeList);
 router.patch('/challengeOut/user', userController.outChallenge);
 router.post('/login', userController.logIn);
 router.post('/logout', userController.logOut);
-router.post('/auth/jwtvalidcheck', userController.verifyToken);
+router.post('/check', userController.check);
 router.get('/user/uniqueid/:user_id', userController.checkIdDupl);
 router.patch('/user/changepw', userController.changePw);
 router.patch('/user/change', userController.change);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2274,6 +2274,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/eslint": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
@@ -2303,6 +2308,15 @@
       "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "@types/html-minifier-terser": {
@@ -12794,6 +12808,16 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-datepicker": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.2.0.tgz",
@@ -15913,6 +15937,15 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universalify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "axios": "^0.21.1",
     "node-sass": "^5.0.0",
     "react": "^17.0.1",
+    "react-cookie": "^4.1.1",
     "react-datepicker": "^4.1.1",
     "react-dom": "^17.0.1",
     "react-js-pagination": "^3.0.3",

--- a/frontend/src/CommonVariable.js
+++ b/frontend/src/CommonVariable.js
@@ -2,7 +2,7 @@
 // export const API_URL = "https://challengeback.herokuapp.com";
 
 // 로컬 프론트 & 백 테스트용
-// export const API_URL = "http://localhost:5000";
+export const API_URL = "http://localhost:5000";
 
 // 배포용
-export const API_URL = "https://alsolvechallenge.herokuapp.com";
+// export const API_URL = "https://alsolvechallenge.herokuapp.com";

--- a/frontend/src/MVVM/Model/UserModel.js
+++ b/frontend/src/MVVM/Model/UserModel.js
@@ -1,10 +1,16 @@
-import React, { useState, useContext, createContext } from 'react';
-
+import React, { useState, useContext, createContext, useEffect } from 'react';
+import { checkUser } from '../../functions/Api'
 const userContext = createContext({});
 const userDispatch = createContext(() => {});
 
 export const UserContextProvider = ({ children }) => {
-	const [userData, setUserData] = useState({});
+	const [userData, setUserData] = useState({auth:'loading'});
+	useEffect(async ()=> {
+		// console.log(userData);
+		await checkUser()
+			.then((user)=> setUserData(user))
+			.catch((err)=> setUserData({auth : "fail"}));
+	}, []);
 	return (
 		<userContext.Provider value={userData}>
 			<userDispatch.Provider value={setUserData}>

--- a/frontend/src/MVVM/ViewModel/ChallengeViewModel.js
+++ b/frontend/src/MVVM/ViewModel/ChallengeViewModel.js
@@ -18,10 +18,10 @@ export const ChallengeLogicProvider = ({ children }) => {
 	console.log(user);
 
 	useEffect(() => {
-		if (user.userId !== undefined) getChallengeList();
+		if (user.user_id !== undefined) getChallengeList();
 	}, [user]);
 	const getChallengeList = async () => {
-		axios.get(`${API_URL}/challenge/list/${user.userId}`).then((res) => {
+		axios.get(`${API_URL}/challenge/list/${user.user_id}`).then((res) => {
 			challengeDispatch(res.data);
 			console.log(res.data);
 		})
@@ -37,7 +37,7 @@ export const ChallengeLogicProvider = ({ children }) => {
 		console.log(challengeInfo);
 		let flag = false;
 		await axios.post(`${API_URL}/challenge`, {
-			user_id: challengeInfo.userId,
+			user_id: challengeInfo.user_id,
 			name: challengeInfo.name,
 			challenge_start: challengeInfo.challenge_start,
 			challenge_end: challengeInfo.challenge_end,
@@ -51,7 +51,7 @@ export const ChallengeLogicProvider = ({ children }) => {
 	const expelChallenge = async (CId, user_id) => {
 		let flag = false;
 		await axios.patch(`/challengeOut/user`, {
-			userId: user_id,
+			user_id: user_id,
 			challengeId: CId
 		}).then((res) => {
 			flag = res.data;

--- a/frontend/src/MVVM/ViewModel/UserViewModel.js
+++ b/frontend/src/MVVM/ViewModel/UserViewModel.js
@@ -5,7 +5,6 @@ import { API_URL } from '../../CommonVariable';
 
 const LoginUserContext = createContext((id, pw) => { });
 const LogoutUserContext = createContext(() => { });
-const GetUserInfoContext = createContext(() => { });
 const SendAuthMailContext = createContext((email) => { });
 const CheckAuthMailContext = createContext((email, authNum) => { });
 const CheckUniqueIdContext = createContext((id) => { });
@@ -19,21 +18,9 @@ export const UserLogicProvider = ({ children }) => {
 	const user = useUserState();
 	const userDispatch = useUserDispatch();
 
-	const GetUserInfo = async () => {
-		await axios.post(`${API_URL}/check`, {}, {
-			withCredentials: true,
-		}).then((res) => {
-			//console.log(res.data);
-			userDispatch({
-				...res.data,
-				auth: "user"
-			});
-		});
-		//console.log(user);
-	};
-	const LoginUser = async (id, pw) => {
+	const LoginUser = async (user_id, user_pw) => {
 		let flag = false;
-		await axios.post(`${API_URL}/login`, { user_id: id, user_pw: pw }, {
+		await axios.post(`${API_URL}/login`, { user_id, user_pw }, {
 			withCredentials: true,
 		}).then((res) => {
 			//console.log(res.data.result);
@@ -143,7 +130,6 @@ export const UserLogicProvider = ({ children }) => {
 	return (
 		<LoginUserContext.Provider value={LoginUser}>
 			<LogoutUserContext.Provider value={LogoutUser}>
-				<GetUserInfoContext.Provider value={GetUserInfo}>
 					<SendAuthMailContext.Provider value={SendAuthMail}>
 						<CheckAuthMailContext.Provider value={CheckAuthMail}>
 							<CheckUniqueIdContext.Provider value={CheckUniqueId}>
@@ -161,7 +147,6 @@ export const UserLogicProvider = ({ children }) => {
 							</CheckUniqueIdContext.Provider>
 						</CheckAuthMailContext.Provider>
 					</SendAuthMailContext.Provider>
-				</GetUserInfoContext.Provider>
 			</LogoutUserContext.Provider>
 		</LoginUserContext.Provider>
 	);
@@ -174,11 +159,6 @@ export function useLoginUser() {
 
 export function useLogoutUser() {
 	const context = useContext(LogoutUserContext);
-	return context;
-}
-
-export function useGetUserInfo() {
-	const context = useContext(GetUserInfoContext);
 	return context;
 }
 

--- a/frontend/src/MVVM/ViewModel/UserViewModel.js
+++ b/frontend/src/MVVM/ViewModel/UserViewModel.js
@@ -5,7 +5,7 @@ import { API_URL } from '../../CommonVariable';
 
 const LoginUserContext = createContext((id, pw) => { });
 const LogoutUserContext = createContext(() => { });
-const VerifyUserContext = createContext(() => { });
+const GetUserInfoContext = createContext(() => { });
 const SendAuthMailContext = createContext((email) => { });
 const CheckAuthMailContext = createContext((email, authNum) => { });
 const CheckUniqueIdContext = createContext((id) => { });
@@ -19,30 +19,33 @@ export const UserLogicProvider = ({ children }) => {
 	const user = useUserState();
 	const userDispatch = useUserDispatch();
 
-	const VerifyUser = async () => {
-		await axios.post(`${API_URL}/auth/jwtvalidcheck`, {}, {
+	const GetUserInfo = async () => {
+		await axios.post(`${API_URL}/check`, {}, {
 			withCredentials: true,
 		}).then((res) => {
-			console.log(res.data);
+			//console.log(res.data);
 			userDispatch({
 				...res.data,
 				auth: "user"
 			});
 		});
-		console.log(user);
+		//console.log(user);
 	};
 	const LoginUser = async (id, pw) => {
 		let flag = false;
 		await axios.post(`${API_URL}/login`, { user_id: id, user_pw: pw }, {
 			withCredentials: true,
 		}).then((res) => {
-			console.log(res.data.result);
+			//console.log(res.data.result);
 			if (res.data.result) flag = true;
+			userDispatch({
+				...res.data.user,
+				auth: "user"
+			});
 		}).catch((err)=> {
 			//console.log(error.response.data);
 			alert(err.response.data.error);
 		});
-		await VerifyUser();
 		return flag;
 	};
 
@@ -140,7 +143,7 @@ export const UserLogicProvider = ({ children }) => {
 	return (
 		<LoginUserContext.Provider value={LoginUser}>
 			<LogoutUserContext.Provider value={LogoutUser}>
-				<VerifyUserContext.Provider value={VerifyUser}>
+				<GetUserInfoContext.Provider value={GetUserInfo}>
 					<SendAuthMailContext.Provider value={SendAuthMail}>
 						<CheckAuthMailContext.Provider value={CheckAuthMail}>
 							<CheckUniqueIdContext.Provider value={CheckUniqueId}>
@@ -158,7 +161,7 @@ export const UserLogicProvider = ({ children }) => {
 							</CheckUniqueIdContext.Provider>
 						</CheckAuthMailContext.Provider>
 					</SendAuthMailContext.Provider>
-				</VerifyUserContext.Provider>
+				</GetUserInfoContext.Provider>
 			</LogoutUserContext.Provider>
 		</LoginUserContext.Provider>
 	);
@@ -174,8 +177,8 @@ export function useLogoutUser() {
 	return context;
 }
 
-export function useVerifyUser() {
-	const context = useContext(VerifyUserContext);
+export function useGetUserInfo() {
+	const context = useContext(GetUserInfoContext);
 	return context;
 }
 

--- a/frontend/src/auth/UserRedirect.js
+++ b/frontend/src/auth/UserRedirect.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
+import { Spinner } from '../components';
 import { useUserState } from '../MVVM/Model/UserModel';
-
 
 function UserRedirect() {
 	const userData = useUserState();
+	//Spinner를 넣고싶다....
 	return (
 		<div>
-			{ userData.auth ? null : <Redirect to="/login">{alert(`로그인이 필요한 서비스입니다.`)}</Redirect> }
+			{ userData.auth === "loading" ? <div/> : 
+				userData.auth === "user" ? null : <Redirect to="/login">{alert(`로그인이 필요한 서비스입니다.`)}</Redirect> }
 		</div>
-	)
+	);
 }
-
+// 
 export default UserRedirect

--- a/frontend/src/components/AlarmModal.js
+++ b/frontend/src/components/AlarmModal.js
@@ -10,7 +10,7 @@ function AlarmModal({ open, closeHandler }) {
 	const GetAlarms = useGetAlarms();
 	const [Alarms, setAlarms] = useState([]);
 	useEffect(() => {
-		GetAlarms(userData.userId).then((docs) => {
+		GetAlarms(userData.user_id).then((docs) => {
 			setAlarms(docs)
 		})
 	}, [userData])

--- a/frontend/src/components/ChallengeList.js
+++ b/frontend/src/components/ChallengeList.js
@@ -3,11 +3,12 @@ import { Button, Grid, Box } from '@material-ui/core';
 import { Spinner } from '../components';
 import { Link } from 'react-router-dom';
 
-function ChallengeList({ list, index, user_id }) {
+function ChallengeList({ list, index, user }) {
+	
 	return (
 		<div>
 			<div className="challengeList">
-				{user_id.userId === undefined ? <Spinner /> :
+				{user.user_id === undefined ? <Spinner /> :
 				<Grid container spacing={3} className="cha_list">
 					{list.map((c, i) => (
 						index === c.state &&
@@ -20,7 +21,7 @@ function ChallengeList({ list, index, user_id }) {
 										</div>
 										<div className="wheel">
 											{
-												c.challenge_leader === user_id.userId ?
+												c.challenge_leader === user.user_id ?
 													<Link className="link" to={`/challenge/manage/${c.challenge_id}`}>
 														<img className="cha_manage" src="/image/바퀴black.png" alt="설정" />
 													</Link>

--- a/frontend/src/components/ChallengeTable.js
+++ b/frontend/src/components/ChallengeTable.js
@@ -37,7 +37,7 @@ function ChallengeTable({ data, user_id, loading}) {
 							<TableCell className="bodyEnd">{DateToString(c.challenge_end)}</TableCell>
 							<TableCell className="bodyLeader">{c.challenge_leader}</TableCell>
 							<TableCell className="bodyJoin">
-								{c.challenge_users.includes(user_id.userId) === false ?
+								{c.challenge_users.includes(user_id.user_id) === false ?
 									<div>
 										<Button className="joinBtn" variant="contained" color="secondary" onClick={() => JoinHandler(c._id)}>Join</Button>
 									</div>
@@ -50,7 +50,7 @@ function ChallengeTable({ data, user_id, loading}) {
 				</TableBody>
 			</Table>
 			}
-			<EntrancePwModal open={pwModal} closeHandler={()=>setPwModal(false)} CId={selChallenge} UId={user_id.userId} />
+			<EntrancePwModal open={pwModal} closeHandler={()=>setPwModal(false)} CId={selChallenge} UId={user_id.user_id} />
 		</div>
 	)
 }

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { useCookies } from 'react-cookie';
 import {
 	Button,
 	AppBar,
@@ -12,24 +11,16 @@ import {
 } from '@material-ui/core';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import { useUserState } from '../MVVM/Model/UserModel';
-import { useLogoutUser, useGetUserInfo } from '../MVVM/ViewModel/UserViewModel';
-
+import { useLogoutUser } from '../MVVM/ViewModel/UserViewModel';
 function Header({ alarmHandler }) {
 	const userState = useUserState();
 	const userlogout = useLogoutUser();
-	const getUserInfo = useGetUserInfo();
 
 	const [isLogined, setIsLogined] = useState(false);
 	const [anchorEl, setAnchorEl] = useState(null);
-	const [cookies, setCookie, removeCookie] = useCookies(['user']);
-	useEffect(() => {
-		if (cookies.user)
-			getUserInfo();
-	}, []);
 
 	useEffect(() => {
 		if (userState.auth === "user") setIsLogined(true);
-		//console.log(userState);
 	}, [userState]);
 
 	const handleClick = (e) => {

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { useCookies } from 'react-cookie';
 import {
 	Button,
 	AppBar,
@@ -11,23 +12,24 @@ import {
 } from '@material-ui/core';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import { useUserState } from '../MVVM/Model/UserModel';
-import { useLogoutUser, useVerifyUser } from '../MVVM/ViewModel/UserViewModel';
+import { useLogoutUser, useGetUserInfo } from '../MVVM/ViewModel/UserViewModel';
 
 function Header({ alarmHandler }) {
 	const userState = useUserState();
 	const userlogout = useLogoutUser();
-	const userVerify = useVerifyUser();
+	const getUserInfo = useGetUserInfo();
 
 	const [isLogined, setIsLogined] = useState(false);
 	const [anchorEl, setAnchorEl] = useState(null);
-
+	const [cookies, setCookie, removeCookie] = useCookies(['user']);
 	useEffect(() => {
-		userVerify();
+		if (cookies.user)
+			getUserInfo();
 	}, []);
 
 	useEffect(() => {
 		if (userState.auth === "user") setIsLogined(true);
-		console.log(userState);
+		//console.log(userState);
 	}, [userState]);
 
 	const handleClick = (e) => {
@@ -80,7 +82,7 @@ function Header({ alarmHandler }) {
 								<div className="alarm">1</div>
 							</IconButton>
 							<IconButton onClick={handleClick}>
-								<img src={`https://github.com/${userState.gitId}.png`} alt={`${userState.gitId}`} className="profileImg" />
+								<img src={`https://github.com/${userState.git_id}.png`} alt={`${userState.git_id}`} className="profileImg" />
 							</IconButton>
 							<Popover
 								id={id}

--- a/frontend/src/components/ManageComponent.js
+++ b/frontend/src/components/ManageComponent.js
@@ -46,7 +46,7 @@ function ManageComponent({ value, index, challengeData, setChallengeData, CId })
 			challenge_start: sDate,
 			challenge_end: eDate,
 			challenge_leader: leader,
-			user_id: user_id.userId,
+			user_id: user_id.user_id,
 			private_key: password
 		};
 		const result = await saveChallenge(CId, challengeInfo);

--- a/frontend/src/components/RequestApproval.js
+++ b/frontend/src/components/RequestApproval.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, Input, RadioGroup, FormControlLabel, Radio, TextareaAutosize } from '@material-ui/core';
 import { useCreateApprove } from '../MVVM/ViewModel/ApproveViewModel';
 
-function RequestApproval({ onClose, challengeId, userId, year, month, day }) {
+function RequestApproval({ onClose, challengeId, user_id, year, month, day }) {
 	const createApprove = useCreateApprove();
 	const [Type, setType] = useState(0);
 	const [Message, setMessage] = useState("");
@@ -18,7 +18,7 @@ function RequestApproval({ onClose, challengeId, userId, year, month, day }) {
 	const submitApprove = async () => {
 		const approveInfo = {
 			ch_id: challengeId,
-			user_id: userId,
+			user_id: user_id,
 			type: Type,
 			message: Message,
 			request_date: `${year}-${month}-${day}`

--- a/frontend/src/functions/Api.js
+++ b/frontend/src/functions/Api.js
@@ -1,0 +1,21 @@
+import React, { useContext, createContext } from 'react';
+import axios from 'axios';
+import { API_URL } from '../CommonVariable';
+import { useCookies } from 'react-cookie';
+
+// 모든 axios요청에 대해 withCredentials을 넣어줌 
+// withCredentials = true 여야 backend에서 cookie에 접근 가능
+// cookie에 JWT있음.
+axios.defaults.withCredentials = true;
+
+async function checkUser(){
+    console.log("asdfheohfise");
+    //const [cookies, setCookie, removeCookie] = useCookies(['user']);
+    const res = await axios.get(`${API_URL}/check`);
+    console.log("yeah");
+    return {
+        ...res.data,
+        auth: "user"
+    };
+}
+export {checkUser};

--- a/frontend/src/pages/ChallengeInfoFix.js
+++ b/frontend/src/pages/ChallengeInfoFix.js
@@ -41,7 +41,7 @@ function ChallengeInfoFix(props) {
 	useEffect(() => {
 		axios.get(`${API_URL}/grass/personal`, {
 			params: {
-				user_id: userData.userId,
+				user_id: userData.user_id,
 				challenge_id: _challengeId,
 				month: today.getMonth() + 1,
 				year: today.getFullYear()
@@ -115,7 +115,7 @@ function ChallengeInfoFix(props) {
 			>
 				<Fade in={open}>
 					<div className="modalPaper">
-						<RequestApproval onClose={handleClose} challengeId={_challengeId} userId={userData.userId} year={Year} month={Month} day={Day} />
+						<RequestApproval onClose={handleClose} challengeId={_challengeId} user_id={userData.user_id} year={Year} month={Month} day={Day} />
 					</div>
 				</Fade>
 			</Modal>

--- a/frontend/src/pages/ChallengeMake.js
+++ b/frontend/src/pages/ChallengeMake.js
@@ -76,7 +76,7 @@ function ChallengeMake({ history }) {
 		}
 		if (Name !== "" && Password === PWcheck) {
 			const challengeInfo = {
-				userId: user.userId,
+				user_id: user.user_id,
 				name: Name,
 				challenge_start: sDate,
 				challenge_end: eDate,

--- a/frontend/src/pages/Main.js
+++ b/frontend/src/pages/Main.js
@@ -6,7 +6,7 @@ import { useUserState } from '../MVVM/Model/UserModel';
 import { useChallengeState } from '../MVVM/Model/ChallengeModel';
 
 function Main() {
-	const user_id = useUserState();
+	const user = useUserState();
 	const challengeData = useChallengeState();
 	const [value, setValue] = useState(0);
 
@@ -64,7 +64,7 @@ function Main() {
 						<AntTab label="참여중인 챌린지" />
 						<AntTab label="종료된 챌린지" />
 					</AntTabs>
-					<ChallengeList list={challengeData} index={value} user_id={user_id} />
+					<ChallengeList list={challengeData} index={value} user={user} />
 				</div>
 			</div>
 		</div>

--- a/frontend/src/pages/MyPage.js
+++ b/frontend/src/pages/MyPage.js
@@ -14,7 +14,7 @@ function MyPage() {
 	const [GitId, setGitId] = useState();
 	const [open, setopen] = useState(false);
 	useEffect(() => {
-		axios.get(`${API_URL}/user/${userData.userId}`).then((res) => {
+		axios.get(`${API_URL}/user/${userData.user_id}`).then((res) => {
 			setName(res.data.user_name);
 			setEmail(res.data.user_email);
 			setGitId(res.data.git_id);
@@ -34,7 +34,7 @@ function MyPage() {
 		setGitId(e.currentTarget.value);
 	};
 	const save = async () => {
-		const result = await Change(userData.userId, Name, GitId);
+		const result = await Change(userData.user_id, Name, GitId);
 		console.log(result)
 		if (result) {
 			alert('정보를 수정하였습니다.');
@@ -48,7 +48,7 @@ function MyPage() {
 					<Grid container spacing={3} justify="center">
 						<Grid item>
 							<Box className="pro_img">
-								<img src={`https://github.com/${userData.gitId}.png`} alt={`${userData.gitId}`} className="pro_img" />
+								<img src={`https://github.com/${userData.git_id}.png`} alt={`${userData.git_id}`} className="pro_img" />
 							</Box>
 						</Grid>
 					</Grid>
@@ -130,7 +130,7 @@ function MyPage() {
 			>
 				<Fade in={open}>
 					<div className="modalPaper">
-						<ChangePassword onClose={handleClose} id={userData.userId} />
+						<ChangePassword onClose={handleClose} id={userData.user_id} />
 					</div>
 				</Fade>
 			</Modal>

--- a/frontend/src/pages/NowChallenge.js
+++ b/frontend/src/pages/NowChallenge.js
@@ -39,8 +39,8 @@ function NowChallenge({ match }) {
 	useEffect(() => {
 		axios.get(`${API_URL}/challenge/${CId}`).then((res) => {
 			if(userData.auth){
-				if(res.data.challenge_users.includes(userData.userId) === false) setPwModal(true);
-				if(res.data.challenge_users.includes(userData.userId) === true) setPwModal(false);
+				if(res.data.challenge_users.includes(userData.user_id) === false) setPwModal(true);
+				if(res.data.challenge_users.includes(userData.user_id) === true) setPwModal(false);
 			}
 		});
 		// todo : grass mvvm 만들기. approve mvvm 이용하기.
@@ -60,7 +60,7 @@ function NowChallenge({ match }) {
 			.catch((error) => { console.log(error); });
 		// my grass
 		axios.get(`${API_URL}/grass/personal`, { params: {
-			user_id: userData.userId,
+			user_id: userData.user_id,
 			challenge_id: CId,
 			month: today.getMonth() + 1,
 			year: today.getFullYear()
@@ -70,7 +70,7 @@ function NowChallenge({ match }) {
 			.catch((error) => { console.log(error); });
 		// other grass
 		axios.get(`${API_URL}/grass/other`, { params: {
-			user_id: userData.userId,
+			user_id: userData.user_id,
 			challenge_id: CId,
 			month: today.getMonth() + 1,
 			year: today.getFullYear()
@@ -89,7 +89,7 @@ function NowChallenge({ match }) {
 		});
 		// approve
 		axios.get(`${API_URL}/approve/list/${CId}`, { params: {
-			user_id: userData.userId
+			user_id: userData.user_id
 		}}).then((res) => {
 			setAdmit(res.data.result);
 			if(res.data.result.length === 0) setAdmit(null);
@@ -238,7 +238,7 @@ function NowChallenge({ match }) {
 					</Grid>
 				</Fade>
 			</Modal>
-			<EntrancePwModal open={pwModal} closeHandler={()=>null} CId={CId} UId={userData.userId} />
+			<EntrancePwModal open={pwModal} closeHandler={()=>null} CId={CId} UId={userData.user_id} />
 		</>
 	);
 }


### PR DESCRIPTION
[Front] 
1. userState 초기값 변경 {} -> {auth: loading}
기존에는 초기값은 {}였고, user정보를 불러오면 auth: user가 되었음.
초기값을 {auth:loading}으로 바꾸고, user정보를 불러오면 auth: user, 실패하면(로그인이 안되어있거나, jwt가 만료되었다던가...) auth: fail로 바꿔줌 
2. JWT인증 api호출을 ViewModel -> Model에서 호출하는 것으로 변경 
UserModel에서 /check api를 호출
3. UserRedirect.js 수정 
이 컴포넌트에서 userState 검사해서 처리해줌.
내가 원하는 방향은 user정보가 loading이면(기다리는 중이면) 스피너 돌고, 결과에 따라 페이지를 로딩해주거나, 에러 띄우거나 였는데 
스피너 띄우는거는 실패했음. 

지금 UserRedirect 안쓰고, 각각 페이지에서 삼항연산자 같은거 이용해서 userState검사해서 에러 안나게 하는걸로 알고있는데, UserRedirect 컴포넌트 가져다 쓰면 될듯. 
(이거 적용하는건 기존에 적용된 페이지 참고 <UserRedirect /> 검색하면 나옴)

[Back]
JWT 미들웨어 구축 
-> JWT발급, 해독 담당 

특히 해독 미들웨어를 app.js 파일에서 router보다 먼저 실행시켜 각 컨트롤러로 요청이 전달되기전에 JWT를 해독해서 req.user에 해독한 정보 넣어줌 (user_id, git_id 들어있음) 

따라서, 각 컨트롤러에서 인증이 필요하면(그룹장만 이 api에 접근이 가능하다던가..등) req.user에서 user_id가져다가 쓰시면 되겠다!

추가로, 이제 JWT해독해서 user정보 얻기 때문에, params나 body에 user_id 넣어 보낼 필요가 없어졌음. req.user에서 가져다쓰는걸로 바꾸고 req에서 user_id안 쓰게 수정하고, 노션에서 api명세 수정해서, 프론트에게 알려주면 될듯. 